### PR TITLE
refactor: use ActivatorUtilities.CreateInstance in AddHook

### DIFF
--- a/src/Ptr.Shared/Hooks/Hosting/HookHostingExtensions.cs
+++ b/src/Ptr.Shared/Hooks/Hosting/HookHostingExtensions.cs
@@ -14,7 +14,7 @@ public static class HookHostingExtensions
             var sharedSystem = p.GetRequiredService<ISharedSystem>();
             var logger = p.GetRequiredService<ILogger<THook>>();
 
-            return (THook)Activator.CreateInstance(typeof(THook), module, name, sharedSystem, logger)!;
+            return ActivatorUtilities.CreateInstance<THook>(p, module, name, sharedSystem, logger);
         });
     }
 


### PR DESCRIPTION
Replace Activator.CreateInstance with ActivatorUtilities.CreateInstance<THook> so hook services can declare extra constructor parameters beyond the 4 fixed ones. Additional dependencies are resolved automatically from DI.